### PR TITLE
Reduce Drone publish and enable Renovate cron

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,13 +7,33 @@ platform:
   arch: amd64
 
 steps:
-- name: build
+- name: build-pr
   image: rancher/dapper:v0.5.8
   commands:
   - dapper ci
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
+
+- name: build-push-tag
+  image: rancher/dapper:v0.5.8
+  commands:
+  - dapper ci
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/main"
+        - "refs/tags/v*"
+    event:
+    - push
 
 - name: github_binary_prerelease
   image: plugins/github-release

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -3,8 +3,8 @@ on:
   # Allows manual/automated ad-hoc trigger
   workflow_dispatch:
   # Run twice in the early morning for initial and follow up steps (create pull request and merge)
-  #schedule:
-  #  - cron: '30 4 * * *'
+  schedule:
+    - cron: '30 4 * * *'
   #  - cron: '30 6 * * *'
 jobs:
   renovate:


### PR DESCRIPTION
As PRs from Renovate are created in the repo itself, each PR triggers a build on `drone-pr` and `drone-publish`. We need to eliminate the `drone-publish` on PR (which is basically a push) by separating the build step and filter on destination branch (`main`).

This also enables running the Renovate workflow on an interval each day.