### PR TITLE
Run Renovate workflow only in weekend

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,7 +14,7 @@ on:
         type: string
   # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
   schedule:
-    - cron: '30 4,6 * * *'
+    - cron: '30 4,6 * * 6,0'
 
 jobs:
   call-workflow:


### PR DESCRIPTION
As the only package managers that are active in this repository are already restricted to updates in the weekend by Renovate, we can just run the workflow on weekends as well as no PR will be created during a non-weekend run.