### PR TITLE
Push existing image instead of building again

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -102,17 +102,19 @@ steps:
     - tag
 
 - name: docker-publish
-  image: plugins/docker
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/rancher-cleanup"
-    tags:
-      - "${DRONE_TAG}-amd64"
-      - "latest-amd64"
-    username:
+  image: rancher/dapper:v0.6.0
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  commands:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - docker push docker.io/rancher/rancher-cleanup:$DRONE_TAG-amd64
+  - docker push docker.io/rancher/rancher-cleanup:latest-amd64
+  environment:
+    DOCKER_USERNAME:
       from_secret: docker_username
+    DOCKER_PASSWORD:
+      from_secret: docker_password
   when:
     instance:
     - drone-publish.rancher.io

--- a/scripts/package
+++ b/scripts/package
@@ -5,11 +5,11 @@ source $(dirname $0)/version
 
 cd $(dirname $0)/..
 
-mkdir -p dist/artifacts
-cp ./cleanup.sh ./verify.sh dist/artifacts/
-
 sed -i -e 's/unreleased/'"$VERSION"'/' cleanup.sh
 sed -i -e 's/unreleased/'"$VERSION"'/' verify.sh
+
+mkdir -p dist/artifacts
+cp ./cleanup.sh ./verify.sh dist/artifacts/
 
 IMAGE=${REPO}/rancher-cleanup:${TAG}
 DOCKERFILE=package/Dockerfile


### PR DESCRIPTION
* Scripts were modified after they were copied to `dist/artifacts`, causing the files in the GitHub release assets to have `unreleased` version
* Drone was rebuilding the image in the docker-publish step which doesnt have the version modification, this changes that to push the existing image from the previous step