### PR TITLE
Dockerfile and release updates to be compatible with arm64 architectures

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ inputs.imageTag || github.repository }}
         with:
-          platforms: linux/arm64/v8,linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: |
             ${{ env.IMAGE_TAG }}:${{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,10 +87,8 @@ jobs:
         env:
           IMAGE_TAG: ${{ inputs.imageTag || github.repository }}
         with:
-          platforms: linux/amd64
+          platforms: linux/arm64/v8,linux/amd64
           push: true
           tags: |
             ${{ env.IMAGE_TAG }}:${{ github.ref_name }}
-            ${{ env.IMAGE_TAG }}:${{ github.ref_name }}-amd64
             ${{ env.IMAGE_TAG }}:latest
-            ${{ env.IMAGE_TAG }}:latest-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,18 @@ FROM registry.suse.com/bci/bci-base:15.5.36.5.47
 
 ENV KUBECTL_VERSION v1.25.15
 WORKDIR /usr/local/bin
-RUN set -x \
- && zypper -n install curl \
- && curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
- && chmod +x kubectl
+ARG TARGETARCH
+
+RUN <<EOT sh
+    set -x && zypper -n install curl
+    
+    if [ "$TARGETARCH" = "arm64" ]; then
+        curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/arm64/kubectl
+    else     
+        curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+    fi
+    chmod +x kubectl
+EOT
 
 COPY cleanup.sh /usr/local/bin/cleanup.sh
 COPY verify.sh /usr/local/bin/verify.sh


### PR DESCRIPTION
This PR aim to fix #91 and contains following updates on :

- Dockerfile : embed **arm64/amd64 kubectl** binary according to building **target architecture**
- Release Action : enable **multi platform build** with **linux/arm64 and linux/amd64**
