### PR TITLE
feat: add EXCLUDE_NAMESPACES env var to skip namespaces during cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ This script will delete all Kubernetes resources belonging to/created by Rancher
 * Deploy the job using `kubectl create -f deploy/rancher-cleanup.yaml`
 * Watch logs using `kubectl  -n kube-system logs -l job-name=cleanup-job  -f`
 
+### Excluding namespaces
+
+Some namespaces in the default lists (such as `istio-system`) may also host non-Rancher workloads. Set the `EXCLUDE_NAMESPACES` environment variable to a space-separated list of namespaces that should be skipped during cleanup:
+
+```
+EXCLUDE_NAMESPACES="istio-system" bash cleanup.sh
+```
+
+When running as a Kubernetes Job, add it to the container `env`:
+
+```yaml
+env:
+  - name: EXCLUDE_NAMESPACES
+    value: "istio-system"
+```
+
+Excluded namespaces are removed from `CATTLE_NAMESPACES`, `TOOLS_NAMESPACES`, and `FLEET_NAMESPACES` before deletion.
+
 
 ## Verify
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -104,6 +104,19 @@ CATTLE_NAMESPACES="local cattle-system cattle-impersonation-system cattle-global
 TOOLS_NAMESPACES="istio-system cattle-resources-system cis-operator-system cattle-dashboards cattle-gatekeeper-system cattle-alerting cattle-logging cattle-pipeline cattle-prometheus rancher-operator-system cattle-monitoring-system cattle-logging-system cattle-elemental-system"
 FLEET_NAMESPACES="cattle-fleet-clusters-system cattle-fleet-local-system cattle-fleet-system fleet-default fleet-local fleet-system"
 
+# Optional: exclude specific namespaces from cleanup. Space-separated list via env var.
+# Useful when a default namespace (e.g. istio-system) is shared with non-Rancher workloads.
+# Example: EXCLUDE_NAMESPACES="istio-system" bash cleanup.sh
+EXCLUDE_NAMESPACES="${EXCLUDE_NAMESPACES:-}"
+if [ -n "$EXCLUDE_NAMESPACES" ]; then
+  for excl in $EXCLUDE_NAMESPACES; do
+    CATTLE_NAMESPACES=$(echo "$CATTLE_NAMESPACES" | tr ' ' '\n' | grep -vx "$excl" | tr '\n' ' ')
+    TOOLS_NAMESPACES=$(echo "$TOOLS_NAMESPACES" | tr ' ' '\n' | grep -vx "$excl" | tr '\n' ' ')
+    FLEET_NAMESPACES=$(echo "$FLEET_NAMESPACES" | tr ' ' '\n' | grep -vx "$excl" | tr '\n' ' ')
+  done
+  echo "Excluded namespaces from cleanup: ${EXCLUDE_NAMESPACES}"
+fi
+
 # Delete rancher install to not have anything running that (re)creates resources
 kcd "-n cattle-system deploy,ds --all"
 kubectl -n cattle-system wait --for delete pod --selector=app=rancher


### PR DESCRIPTION
## Summary
Add an optional `EXCLUDE_NAMESPACES` environment variable that lets operators skip one or more namespaces from the cleanup script. Empty by default — existing behavior is unchanged.

## Motivation

The cleanup script hardcodes `istio-system` (alongside other tooling namespaces) in `TOOLS_NAMESPACES` (cleanup.sh#L104). It is then deleted as part of the standard cleanup loop, with finalizers stripped, so the namespace cannot resist:

```bash
TOOLS_NAMESPACES="istio-system cattle-resources-system ..."

for NS in $TOOLS_NAMESPACES $FLEET_NAMESPACES $CATTLE_NAMESPACES; do
  ...
  kcdns "$NS"           # strips finalizers, then deletes the namespace
done
```

Because namespace deletion in Kubernetes is a hard cascade, this removes **every** resource inside `istio-system` — including Istio itself, even when Istio was installed independently and never managed by Rancher. Rancher only "claims" the namespace via `field.cattle.io/projectId` when it is added to a Project, but the cleanup script makes no distinction between namespaces Rancher created vs namespaces it merely annotated.

In environments where Istio (or any other namespace in the default list) is shared infrastructure not owned by Rancher, running `cleanup.sh` causes an unintended outage. The only available workaround today is to fork the repo and edit the namespace lists, which is fragile and easy to forget across upgrades.

This PR adds an opt-in `EXCLUDE_NAMESPACES` env var that lets operators preserve specific namespaces during cleanup, without forking the script.

## Change
- `cleanup.sh`: read `EXCLUDE_NAMESPACES` (space-separated), strip any matching entries from `CATTLE_NAMESPACES`, `TOOLS_NAMESPACES`, and `FLEET_NAMESPACES` before the delete loops run. Empty default preserves current behavior.
- `README.md`: usage doc + Kubernetes Job snippet.

## Example
```
EXCLUDE_NAMESPACES="istio-system" bash cleanup.sh
```

Job manifest:
```yaml
env:
  - name: EXCLUDE_NAMESPACES
    value: "istio-system"
```

## Test plan
- [x] `EXCLUDE_NAMESPACES=""` (or unset) → no behavior change, all three lists identical to before.
- [x] `EXCLUDE_NAMESPACES="istio-system"` → `istio-system` removed from `TOOLS_NAMESPACES`, other namespaces untouched.
- [x] `EXCLUDE_NAMESPACES="istio-system fleet-default"` → multi-namespace exclusion works across lists.